### PR TITLE
write redis requirepass configuration based on REDIS_PASSWORD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM redis:2.8.19
 ENV REDIS_PASSWORD password
 ENV REDIS_DATABASE 0
 
-COPY conf/redis.conf /usr/local/etc/redis.conf
+ADD redis.sh /usr/local/bin/redis.sh
 
-CMD ["redis-server", "/usr/local/etc/redis.conf"]
+CMD ["/usr/local/bin/redis.sh"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,15 @@ Run a local Redis.
 
 ## Usage
 
-    $ docker run -p 6379 convox/redis
+Any of the following:
+
+    $ docker-compose up
+    $ REDIS_PASSWORD=secret docker-compose up
+
+    $ docker run -p 6379:6379 convox/redis
+    $ docker run -e REDIS_PASSWORD=secret -p 6379:6379 convox/redis
+
+If REDIS_PASSWORD env is not specified, the server password is 'password'.
 
 ## License
 

--- a/conf/redis.conf
+++ b/conf/redis.conf
@@ -1,1 +1,0 @@
-requirepass password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+redis:
+  build: .
+  environment:
+    REDIS_PASSWORD:
+  ports:
+   - "6379:6379"

--- a/redis.sh
+++ b/redis.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+export REDIS_PASSWORD=${REDIS_PASSWORD:-password}
+
+echo "requirepass ${REDIS_PASSWORD}" > /usr/local/etc/redis.conf
+
+exec redis-server /usr/local/etc/redis.conf


### PR DESCRIPTION
Add docker-compose.yml that takes REDIS_PASSWORD from host, to facilitate building an AMI with convox/build
