### PR TITLE
Fix #4: Enable redis persistence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,10 @@ ENV LINK_SCHEME redis
 ENV LINK_PASSWORD password
 ENV LINK_PATH /0
 
+RUN mkdir /data && chown nobody:nobody /data
+VOLUME /data
+WORKDIR /data
+
 COPY docker-entrypoint.sh /
 
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -12,10 +12,18 @@ with a much smaller footprint. It achieves that by basing itself off the great
 
 ## Usage
 
+Ephemeral redis container:
+
 ```bash
 $ docker run -e LINK_PASSWORD=foo -p 6379:6379 convox/redis
 $ redis-cli -h $(boot2docker ip) -a foo
 192.168.59.103:6379>
+```
+
+Enable persistence with shared volume on host:
+
+```bash
+$ docker run -e LINK_PASSWORD=foo -p 6379:6379 -v /tmp/redis-data:/data convox/redis redis-server /tmp/redis.conf --appendonly yes
 ```
 
 ## Why?


### PR DESCRIPTION
### Changes
- Create and chown `/data/`
- Create a docker volume for `/data` and set `WORKDIR`
- Update readme with usage instructions for persistence

These are copied (slightly modified) from the [official redis Dockerfile](https://github.com/docker-library/redis/blob/5d3e1e5ff708d038527c719d52f3e87f1970d721/3.2/alpine/Dockerfile#L31-L33)
### Usage:
- Set docker command to: `redis-server /tmp/redis.conf --appendonly yes`
- Create a shared volume on your host: `-v /tmp/redis-data:/data`
### Demo:

![](https://mwarkentin-snaps.s3.amazonaws.com/convox-redis-persistence-demo.gif)
