### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-echo "requirepass ${LINK_PASSWORD}" >> /tmp/redis.conf
+[ ! -z ${LINK_PASSWORD} ] && echo "requirepass ${LINK_PASSWORD}" >> /tmp/redis.conf
 
 exec gosu nobody "$@"


### PR DESCRIPTION
Only append `requirepass` directive to `/tmp/redis.conf` if `$LINK_PASSWORD` has a non-zero length, so we can use redis without a password.