### PR TITLE
Allow for blank password (no auth)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
-echo "requirepass ${LINK_PASSWORD}" >> /tmp/redis.conf
+if [ -z "${LINK_PASSWORD}" ]
+then
+  echo "protected-mode no" >> /tmp/redis.conf
+else
+  echo "requirepass ${LINK_PASSWORD}" >> /tmp/redis.conf
+fi
 
 exec gosu nobody "$@"


### PR DESCRIPTION
Since ElastiCache Redis instances don't use authentication, there should be a way to launch Redis instances in development which also don't use authentication. (I actually ran into an issue related to this).

With this change, setting `LINK_PASSWORD` to empty string causes the instance to disable authentication. 