### PR TITLE
Easier no-password mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN chmod +x /usr/local/bin/gosu
 
 # convox assembles these into a URL during `convox start`
 ENV LINK_SCHEME redis
-ENV LINK_PASSWORD password
 ENV LINK_PATH /0
 
 RUN mkdir /data && chown nobody:nobody /data

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
-[ ! -z ${LINK_PASSWORD} ] && echo "requirepass ${LINK_PASSWORD}" >> /tmp/redis.conf
+if [ ! -z "${LINK_PASSWORD}" ]; then
+  echo "requirepass ${LINK_PASSWORD}" >> /tmp/redis.conf
+else
+  echo "protected-mode no" >> /tmp/redis.conf
+fi
 
 exec gosu nobody "$@"


### PR DESCRIPTION
This makes it easier to use Redis in no-password mode. 

Want a password? Set `- LINK_PASSWORD=mypassword` in the `environment` section of your service definition. Don't want a password? Do nothing.


----
Testing with `convox start`, where `redis` is a process using this image and `web` is a process that's connected to it with `links`:

```
// Without LINK_PASSWORD set

[...]
web       │ running: docker run -i --rm --name notifications-web --add-host redis:172.17.0.4 -e REDIS_SCHEME=redis -e REDIS_HOST=172.17.0.4 -e REDIS_PORT=6379 -e REDIS_PATH=/0 -e REDIS_USERNAME= -e REDIS_PASSWORD= -e REDIS_URL=redis://172.17.0.4:6379/0 -p 0:80 -p 0:8000 notifications/web sh -c /app/bin/web
[...]

$ redis-cli -p 32787 "info"
# Server
[...]

// With LINK_PASSWORD set

[...]
web       │ running: docker run -i --rm --name notifications-web --add-host redis:172.17.0.4 -e REDIS_SCHEME=redis -e REDIS_HOST=172.17.0.4 -e REDIS_PORT=6379 -e REDIS_PATH=/0 -e REDIS_USERNAME= -e REDIS_PASSWORD=foo -e REDIS_URL=redis://:foo@172.17.0.4:6379/0 -p 0:80 -p 0:8000 notifications/web sh -c /app/bin/web
[...]

$ redis-cli -p 32793 "info"
NOAUTH Authentication required.

$ redis-cli -h 0.0.0.0 -p 32793 -a foo 'info'
# Server
[...]

```
----
Testing in free-standing use:
```
// With LINK_PASSWORD set

$ docker run -it -p 6379:6379 -e 'LINK_PASSWORD=foo' redis/dml

$ redis-cli -h 0.0.0.0 -p 6379 'info'
NOAUTH Authentication required.

$ redis-cli -h 0.0.0.0 -p 6379 -a foo 'info'
# Server
[...]

// Without LINK_PASSWORD set

$ docker run -it -p 6379:6379 redis/dml

$ redis-cli -h 0.0.0.0 -p 6379 'info'
# Server
[...]

$ redis-cli -h 0.0.0.0 -p 6379 -a foo 'info'
# Server
[...]
```